### PR TITLE
feat: export Signal type and SignalOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kasper-js",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "description": "A lightweight component framework with fine-grained Signal-based reactivity. No virtual DOM. No magic compiler. Just components, signals, and surgical DOM updates",
   "main": "./dist/kasper.js",
   "module": "./dist/kasper.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,8 @@ import { navigate, Router } from "./router";
 import { Scanner } from "./scanner";
 import { TemplateParser } from "./template-parser";
 import { Transpiler } from "./transpiler";
-import { signal, effect, computed, batch, watch } from "./signal";
+import { Signal, SignalOptions, signal, effect, computed, batch, watch } from "./signal";
 import { nextTick } from "./scheduler";
 
-export { ExpressionParser, Interpreter, Scanner, TemplateParser, Transpiler, signal, effect, computed, batch, watch, nextTick };
+export { ExpressionParser, Interpreter, Scanner, TemplateParser, Transpiler, Signal, SignalOptions, signal, effect, computed, batch, watch, nextTick };
 export { execute, transpile, bootstrap as App, lazy, Component, navigate, Router };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,10 @@ import { navigate, Router } from "./router";
 import { Scanner } from "./scanner";
 import { TemplateParser } from "./template-parser";
 import { Transpiler } from "./transpiler";
-import { Signal, SignalOptions, signal, effect, computed, batch, watch } from "./signal";
+import { Signal, signal, effect, computed, batch, watch } from "./signal";
+import type { SignalOptions } from "./signal";
 import { nextTick } from "./scheduler";
 
-export { ExpressionParser, Interpreter, Scanner, TemplateParser, Transpiler, Signal, SignalOptions, signal, effect, computed, batch, watch, nextTick };
+export { ExpressionParser, Interpreter, Scanner, TemplateParser, Transpiler, Signal, signal, effect, computed, batch, watch, nextTick };
+export type { SignalOptions };
 export { execute, transpile, bootstrap as App, lazy, Component, navigate, Router };


### PR DESCRIPTION
## Summary
- Exports `Signal` class and `SignalOptions` interface from the public API so consumers can use them as type annotations directly
- Bumps version to 0.3.25

## Test plan
- [ ] Verify `import { Signal, SignalOptions } from 'kasper-js'` resolves correctly in a consuming project
- [ ] Confirm existing `signal()`, `computed()`, `watch()` usage is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)